### PR TITLE
Build as CommonJS

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,5 +1,17 @@
-export * from "./xmp-fonts";
-export * from "./xmp-ids";
-export * from "./xmp-markers";
-export * from "./xmp-thumbnails";
-export * from "./xmp";
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __exportStar = (this && this.__exportStar) || function(m, exports) {
+    for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+__exportStar(require("./xmp-fonts"), exports);
+__exportStar(require("./xmp-ids"), exports);
+__exportStar(require("./xmp-markers"), exports);
+__exportStar(require("./xmp-thumbnails"), exports);
+__exportStar(require("./xmp"), exports);

--- a/dist/xmp-fonts.js
+++ b/dist/xmp-fonts.js
@@ -1,11 +1,15 @@
-import { mapElements } from "./xmp";
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getFonts = void 0;
+var xmp_1 = require("./xmp");
 /**
  * Extracts all font definitions in an XMP document.
  * @param xmp XmpDocument to load fonts from.
  */
-export function getFonts(xmp) {
+function getFonts(xmp) {
     var XPATH_EXPR = "//rdf:RDF/rdf:Description/xmpTPg:Fonts/rdf:Bag/rdf:li";
-    return mapElements(xmp, XPATH_EXPR, function (node) {
+    return xmp_1.mapElements(xmp, XPATH_EXPR, function (node) {
         return null;
     });
 }
+exports.getFonts = getFonts;

--- a/dist/xmp-ids.js
+++ b/dist/xmp-ids.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/dist/xmp-markers.js
+++ b/dist/xmp-markers.js
@@ -1,9 +1,12 @@
-import { NAMESPACES } from "./xmp";
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getCuePointMarkers = void 0;
+var xmp_1 = require("./xmp");
 /**
  * Extracts all markers from an XMP document.
  * @param xmp XMP document to parse.
  */
-export function getCuePointMarkers(xmp) {
+function getCuePointMarkers(xmp) {
     var cuePointMarkers = xmp.findElements("//rdf:RDF/rdf:Description/xmpDM:Tracks/rdf:Bag/rdf:li/rdf:Description").iterateNext();
     if (cuePointMarkers === null)
         return null;
@@ -13,14 +16,14 @@ export function getCuePointMarkers(xmp) {
         return null;
     // get framerate (frames per second)
     // e.g. xmpDM:frameRate="f48000"
-    var frameRate = parseInt(cuePointMarkersElem.attributes.getNamedItemNS(NAMESPACES.xmpDM, "frameRate").value.substr(1));
+    var frameRate = parseInt(cuePointMarkersElem.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpDM, "frameRate").value.substr(1));
     var markerNodes = xmp.findElements("//rdf:RDF/rdf:Description/xmpDM:Tracks/rdf:Bag/rdf:li/rdf:Description/xmpDM:markers/rdf:Seq//rdf:li/rdf:Description");
     var markers = [];
     var el = markerNodes.iterateNext();
     while (el) {
         var markerElement = el;
         // get marker startTime
-        var markerStartTime = markerElement.attributes.getNamedItemNS(NAMESPACES.xmpDM, "startTime").value;
+        var markerStartTime = markerElement.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpDM, "startTime").value;
         var markerFrameRate = frameRate;
         // marker startTime may contain a custom framerate, override the parent framerate
         // e.g. xmpDM:startTime="4801365"
@@ -28,10 +31,11 @@ export function getCuePointMarkers(xmp) {
             markerFrameRate = parseInt(markerStartTime.substr(markerStartTime.indexOf('f')).substr(1));
         }
         markers.push({
-            name: markerElement.attributes.getNamedItemNS(NAMESPACES.xmpDM, "name").value,
+            name: markerElement.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpDM, "name").value,
             timestamp: parseInt(markerStartTime) / markerFrameRate * 1000
         });
         el = markerNodes.iterateNext();
     }
     return markers;
 }
+exports.getCuePointMarkers = getCuePointMarkers;

--- a/dist/xmp-thumbnails.js
+++ b/dist/xmp-thumbnails.js
@@ -1,30 +1,33 @@
-import { NAMESPACES, getChildElement } from "./xmp";
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getThumbnailImages = exports.getThumbnails = void 0;
+var xmp_1 = require("./xmp");
 /**
  * Extracts all thumbnails from an XMP document.
  * @param xmp XMP document to parse.
  */
-export function getThumbnails(xmp) {
+function getThumbnails(xmp) {
     var results = xmp.findElements("//rdf:RDF/rdf:Description/xmp:Thumbnails/rdf:Alt/rdf:li");
     var thumbnails = [];
     var el = results.iterateNext();
     while (el) {
         if (el.hasChildNodes()) {
-            var imageEl = getChildElement(el, "image");
+            var imageEl = xmp_1.getChildElement(el, "image");
             if (imageEl) {
                 thumbnails.push({
                     image: imageEl.textContent,
-                    format: getChildElement(el, "format").textContent,
-                    width: parseInt(getChildElement(el, "width").textContent, 10),
-                    height: parseInt(getChildElement(el, "height").textContent, 10)
+                    format: xmp_1.getChildElement(el, "format").textContent,
+                    width: parseInt(xmp_1.getChildElement(el, "width").textContent, 10),
+                    height: parseInt(xmp_1.getChildElement(el, "height").textContent, 10)
                 });
             }
         }
         else {
-            var imageAttr = el.attributes.getNamedItemNS(NAMESPACES.xmpGImg, "image");
+            var imageAttr = el.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpGImg, "image");
             if (imageAttr) {
-                var format = el.attributes.getNamedItemNS(NAMESPACES.xmpGImg, "format");
-                var width = el.attributes.getNamedItemNS(NAMESPACES.xmpGImg, "width");
-                var height = el.attributes.getNamedItemNS(NAMESPACES.xmpGImg, "height");
+                var format = el.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpGImg, "format");
+                var width = el.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpGImg, "width");
+                var height = el.attributes.getNamedItemNS(xmp_1.NAMESPACES.xmpGImg, "height");
                 thumbnails.push({
                     image: imageAttr.value,
                     format: format.value,
@@ -37,13 +40,14 @@ export function getThumbnails(xmp) {
     }
     return thumbnails;
 }
+exports.getThumbnails = getThumbnails;
 /**
  * Returns all thumbnails in the XMP as HTML-compatible image elements that
  * can be immediately inserted into the DOM. Widths and heights are automatically
  * set.
  * @param xmp XMP document to parse
  */
-export function getThumbnailImages(xmp) {
+function getThumbnailImages(xmp) {
     return getThumbnails(xmp).map(function (value) {
         console.log("Rendering image element for thumbnail");
         var img = new Image(value.width, value.height);
@@ -51,3 +55,4 @@ export function getThumbnailImages(xmp) {
         return img;
     });
 }
+exports.getThumbnailImages = getThumbnailImages;

--- a/dist/xmp.js
+++ b/dist/xmp.js
@@ -1,4 +1,7 @@
-export var NAMESPACES = {
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.mapElements = exports.getChildElement = exports.loadXmpFromFile = exports.XmpDocument = exports.NAMESPACES = void 0;
+exports.NAMESPACES = {
     dc: "http://purl.org/dc/elements/1.1/",
     illustrator: "http://ns.adobe.com/illustrator/1.0/",
     pdf: "http://ns.adobe.com/pdf/1.3/",
@@ -33,7 +36,7 @@ var XmpDocument = /** @class */ (function () {
         * can find a better solution!
         */
         this._resolver = function (prefix) {
-            return NAMESPACES[prefix] || "";
+            return exports.NAMESPACES[prefix] || "";
         };
     }
     /**
@@ -69,13 +72,13 @@ var XmpDocument = /** @class */ (function () {
     };
     return XmpDocument;
 }());
-export { XmpDocument };
+exports.XmpDocument = XmpDocument;
 /**
  * Extracts the XMP metadata from a file input.
  * @param file The read to read from.
  * @param callback The callback to run with the extracted XML document.
  */
-export function loadXmpFromFile(file, callback) {
+function loadXmpFromFile(file, callback) {
     var XMP_START = "<x:xmpmeta", XMP_END = "</x:xmpmeta>", DOC_TYPE = "text/xml", reader = new FileReader();
     reader.onload = function (e) {
         // load the XMP by sub-stringing the stringified binary data; seems
@@ -92,7 +95,8 @@ export function loadXmpFromFile(file, callback) {
     };
     reader.readAsText(file);
 }
-export function getChildElement(parent, name) {
+exports.loadXmpFromFile = loadXmpFromFile;
+function getChildElement(parent, name) {
     var child;
     for (var i = 0; i < parent.childNodes.length; i++) {
         child = parent.childNodes[i];
@@ -102,7 +106,8 @@ export function getChildElement(parent, name) {
     }
     return null;
 }
-export function mapElements(xmp, expression, mapping) {
+exports.getChildElement = getChildElement;
+function mapElements(xmp, expression, mapping) {
     var results = [], xpath = xmp.findElements(expression), node = xpath.iterateNext();
     while (node) {
         results.push(mapping(node));
@@ -110,3 +115,4 @@ export function mapElements(xmp, expression, mapping) {
     }
     return results;
 }
+exports.mapElements = mapElements;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,29 @@
 {
   "name": "@121cast/xmp-js",
-  "version": "1.0.1",
-  "lockfileVersion": 1,
+  "version": "2.1.0",
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "typescript": {
+  "packages": {
+    "": {
+      "name": "@121cast/xmp-js",
+      "version": "2.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^3.9.3"
+      }
+    },
+    "node_modules/typescript": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
       "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "removeComments": false,
-    "module": "ES6",
+    "module": "CommonJS",
     "outDir": "dist",
     "target": "ES5",
   },


### PR DESCRIPTION
I was checking we didn't have any problems with this library with the CMS and I realised it was being built as an ES module, not CommonJS (like the waveform library). So I couldn't import it, I get `SyntaxError: Unexpected token 'export'` etc.

I assume we can get around this with the current CMS due to webpack.

I'm not sure how we publish this, or whether we should be ignoring the built files, etc, this is just a starting point.